### PR TITLE
Discard stats entries related to private cores

### DIFF
--- a/src/main/java/org/jenkinsci/infra/log/Decrypter.java
+++ b/src/main/java/org/jenkinsci/infra/log/Decrypter.java
@@ -34,6 +34,7 @@ public class Decrypter {
     private final Scrambler scrambler;
     private final LogLineFactory llf = new LogLineFactory();
     private final Predicate<LogLine> infra621 = new INFRA621();
+    private final Predicate<LogLine> publicCores = new PublicCores();
 
     public Decrypter(File keyFile, Scrambler scrambler) throws IOException, GeneralSecurityException {
         this.cipher = createCipher(keyFile);
@@ -91,6 +92,9 @@ public class Decrypter {
                         continue;
                     }
                     if (infra621.apply(ll)) {
+                        continue;
+                    }
+                    if (publicCores.apply(ll)) {
                         continue;
                     }
                     scrambler.handleJSONObject(ll.usage);

--- a/src/main/java/org/jenkinsci/infra/log/PublicCores.java
+++ b/src/main/java/org/jenkinsci/infra/log/PublicCores.java
@@ -1,0 +1,39 @@
+package org.jenkinsci.infra.log;
+
+import com.google.common.base.Predicate;
+import hudson.util.IOUtils;
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.HashSet;
+
+/**
+ * @author Daniel Beck
+ */
+public class PublicCores implements Predicate<LogLine> {
+
+    private HashSet<String> publicCores;
+
+    public PublicCores() throws IOException {
+        publicCores = new HashSet<>();
+        
+        String s = IOUtils.toString(new URL("https://repo.jenkins-ci.org/api/search/versions?g=org.jenkins-ci.main&a=jenkins-core&repos=releases").openStream(), "UTF-8");
+        JSONArray o = JSONObject.fromObject(s).getJSONArray("results");
+
+        for (int i = 0; i < o.size(); i++) {
+            JSONObject entry = o.getJSONObject(i);
+            publicCores.add(entry.getString("version"));
+        }
+    }
+
+    @Override
+    public boolean apply(LogLine ll) {
+        return !isPublic(ll.usage.getString("version"));
+    }
+
+    boolean isPublic(String vs) {
+        return publicCores.contains(vs);
+    }
+}

--- a/src/test/java/org/jenkinsci/infra/log/PublicCoresTest.java
+++ b/src/test/java/org/jenkinsci/infra/log/PublicCoresTest.java
@@ -1,0 +1,42 @@
+package org.jenkinsci.infra.log;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class PublicCoresTest {
+    private final PublicCores i = new PublicCores();
+    
+    @Test
+    public void basics() {
+        y("1.642");
+        y("2.0");
+        y("2.0-beta-2");
+        y("2.0-rc-1");
+        y("2.0");
+        y("2.7.4");
+        y("2.19.4");
+        y("1.509.3.JENKINS-14362-jzlib");
+        y("1.509.2.JENKINS-8856-diag");
+        y("1.565.1.JENKINS-22395-dropLinks");
+        y("1.396");
+
+        n("1.395");
+        n("2.19.5");
+        n("2.32.2.1");
+        n("2.32.2-whatever");
+    }
+
+    private void y(String... args) {
+        for (String s : args) {
+            assertTrue(s, i.isPublic(s));
+        }
+    }
+
+    private void n(String... args) {
+        for (String s : args) {
+            assertFalse(s, i.isPublic(s));
+        }
+    }
+}


### PR DESCRIPTION
So far, we only discard entire stats entries for the cores affected by https://wiki.jenkins-ci.org/display/JENKINS/Usage+Statistics+Privacy+Advisory+2016-03-30 so dropping all the data just because someone runs 2.46.1-danielbeck-1 could be considered too much.

Possible alternatives:
*  keep the affected version numbers encrypted and filter them out in https://github.com/jenkinsci/infra-statistics
* normalize them to the closest public prefix (e.g. 2.46.1.2.3-whatever would count towards 2.46.1) if possible, and only discard if no such prefix exists. This could be done in infra-statistics as well.