### PR TITLE
[INFRA-1350] Consider blacklisted plugins public

### DIFF
--- a/src/main/java/org/jenkinsci/infra/log/ListOfPublicPlugins.java
+++ b/src/main/java/org/jenkinsci/infra/log/ListOfPublicPlugins.java
@@ -6,6 +6,8 @@ import net.sf.json.JSONObject;
 import java.io.IOException;
 import java.net.URL;
 import java.security.GeneralSecurityException;
+import java.util.HashSet;
+import java.util.Properties;
 import java.util.Set;
 
 /**
@@ -23,7 +25,15 @@ public class ListOfPublicPlugins {
         s = s.substring(0, s.lastIndexOf('}')+1);
 
         JSONObject o = JSONObject.fromObject(s);
-        publicPluginNames = o.getJSONObject("plugins").keySet();
+        publicPluginNames = new HashSet<String>(o.getJSONObject("plugins").keySet());
+
+        // TODO since this isn't _that_ important, should we wrap this in try/catch and discard exceptions?
+        Properties p = new Properties();
+        p.load(new URL("https://raw.githubusercontent.com/jenkins-infra/backend-update-center2/master/src/main/resources/artifact-ignores.properties").openStream());
+        for (String key : p.stringPropertyNames()) {
+            // this will add useless entries of the form id-version for plugins that aren't actually blacklisted, but that's not a problem -- they'll never be checked.
+            publicPluginNames.add(key);
+        }
     }
 
     public String escape(String pluginName) throws IOException, GeneralSecurityException {

--- a/src/test/java/org/jenkinsci/infra/log/ListOfPublicPluginsTest.java
+++ b/src/test/java/org/jenkinsci/infra/log/ListOfPublicPluginsTest.java
@@ -1,0 +1,18 @@
+package org.jenkinsci.infra.log;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ListOfPublicPluginsTest {
+    @Test
+    public void testInclusions() throws Exception {
+        Scrambler scrambler = new Scrambler(new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+        ListOfPublicPlugins list = new ListOfPublicPlugins(scrambler);
+        Assert.assertEquals("junit", list.escape("junit")); // sample for plugin being published
+        Assert.assertEquals("girls", list.escape("girls")); // safe to assume we won't restore distribution of this
+
+        // Ensure plugins that are neither blacklisted nor available show as 'privateplugin-' followed by not the plugin name
+        Assert.assertTrue(list.escape("i-don-t-exist").startsWith("privateplugin-"));
+        Assert.assertFalse(list.escape("i-don-t-exist").contains("exist"));
+    }
+}


### PR DESCRIPTION
[INFRA-1350](https://issues.jenkins-ci.org/browse/INFRA-1350)

Effect can be seen e.g. on https://wiki.jenkins.io/display/JENKINS/PTC+Integrity+Plugin#PTCIntegrityPlugin-Overview – since the plugin was suspended for several months, April stats (first 10 days) were very low and there's nothing afterwards. Will be restored once the September stats are in.

A possible reason we might *not* want to do this: These are instances advertising that they're vulnerable. Then again, once the plugin (e.g. Integrity above) gets fixed and we restore distribution, we receive all the data again, even for those releases that are known vulnerable. So it's not like we're much better today than we'd be with this PR.

Possible ways forward:
* Merge this and collect all the things that have ever been public.
* Properly blacklist specific releases from usage stats, and spend way more time on the ignores file to ensure we continue to exclude all affected versions from stats gathering. Today, we don't have the data, as the ignores file is primarily used for plugin distribution, not stats filtering.

CC @orrc @batmat
