### PR TITLE
Consider alpha/beta only plugins to be public

### DIFF
--- a/src/main/java/org/jenkinsci/infra/log/ListOfPublicPlugins.java
+++ b/src/main/java/org/jenkinsci/infra/log/ListOfPublicPlugins.java
@@ -20,9 +20,8 @@ public class ListOfPublicPlugins {
     public ListOfPublicPlugins(Scrambler scrambler) throws IOException {
         this.scrambler = scrambler;
 
-        String s = IOUtils.toString(new URL("http://updates.jenkins-ci.org/update-center.json").openStream(), "UTF-8");
-        s = s.substring(s.indexOf('{'));
-        s = s.substring(0, s.lastIndexOf('}')+1);
+        // use the experimental update center to include plugins that are considered alpha/beta only
+        String s = IOUtils.toString(new URL("http://updates.jenkins-ci.org/experimental/update-center.actual.json").openStream(), "UTF-8");
 
         JSONObject o = JSONObject.fromObject(s);
         publicPluginNames = new HashSet<String>(o.getJSONObject("plugins").keySet());


### PR DESCRIPTION
This affects usage stats collection of the following plugins that have only ever been released to the experimental update center (and their release date):

* `blueocean-analytics-tools` 2016-08-12
* `blueocean-executor-info` 2017-10-10
* `configuration-as-code` 2018-05-30
* `container-slaves` 2015-09-21
* `help-editor` 2016-08-23
* `heroku-jenkins-plugin` 2012-10-29
* `trial-balloon` 2013-09-21
* `workflow-stm` 2014-08-25
* `yaml-project` 2015-10-22

For something like configuration-as-code, the numbers could be interesting.

For some of the others it could inform potential suspension of distribution, as they're clearly unmaintained and never got to a release.

In any case, these are not private-source plugins we accidentally capture via usage stats, so we can include them.

Untested.