### PR TITLE
Remove job type package name filter

### DIFF
--- a/src/main/java/org/jenkinsci/infra/log/ListOfJobTypes.java
+++ b/src/main/java/org/jenkinsci/infra/log/ListOfJobTypes.java
@@ -27,14 +27,7 @@ public class ListOfJobTypes {
      * @param jsonKey
      *      The job type in JSON key-safe format, which replaces '.' with '-'.
      */
-    public boolean isPublic(String jsonKey) {
-        // anything in the public namespace
-        if (jsonKey.startsWith("hudson-")
-         || jsonKey.startsWith("org-jvnet-hudson")
-         || jsonKey.startsWith("org-jenkinsci"))
-            return true;
-
-        // other ones that are in the public update center
+    public boolean isPublic(String jsonKey)
         return fqcns.contains(jsonKey.replace('-','.'));
     }
 }


### PR DESCRIPTION
This hasn't made sense since we've started explicitly listing known types.

Untested.